### PR TITLE
Fix CI test reliability on foss/2025b

### DIFF
--- a/scripts/correct_baserun_timestamps
+++ b/scripts/correct_baserun_timestamps
@@ -1,5 +1,15 @@
 #! /bin/tcsh -f
 cd baserun
+# Ensure the b2ag/b2ah/b2ai/b2ar input .dat files are older than the
+# derived output files touched below.  Otherwise, when a tarball is
+# extracted with -m (mtimes set to extraction time) the .dat files can
+# end up newer than the corresponding outputs by a few sub-second
+# fractions, which makes GNU make try to regenerate b2fgmtry / b2fpardf
+# / b2fstati / b2frates from scratch (and, for b2fgmtry, fail because
+# the carre mesh file is not on the in-tree search path).
+foreach i (b2ag.dat b2ah.dat b2ai.dat b2ar.dat stra.dat weis.dat)
+  [ -s $i ] && touch -d '10 seconds ago' $i
+end
 touch b2ag.prt
 [ -s b2fgmtry ] && touch b2fgmtry || echo 'No valid b2fgmtry file found'
 if (${COMPILER} == "HP" ) then


### PR DESCRIPTION
Two fixes that complete the foss/2025b + intel/2025b porting effort and make the OpenMP and GNU CI tests pass on SDCC:

* scripts/correct_baserun_timestamps: pre-age the b2ag/b2ah/b2ai/b2ar input .dat files by 10 s before touching the derived output files. Without this, when a baserun tarball is extracted with 'tar -xhmzf -m' the .dat input mtimes (set to extraction time) can land sub-second newer than the just-touched outputs.  GNU make then triggers a b2ag regeneration that fails because the carre mesh file is not reachable from the in-tree search path used by open_file.F.  Affects all CI tests (OpenMP, GNU, Intel) whenever a baserun is extracted; visible on faster I/O / parallel toolchains, latent elsewhere.

* modules/Eirene: bump submodule pointer to fix the b2mod_dimensions.mod duplicate-source race during parallel cmake builds in the GNU CI test.