### PR TITLE
Included support for Linux ARM

### DIFF
--- a/scripts/install_dependencies
+++ b/scripts/install_dependencies
@@ -1504,7 +1504,7 @@ if ("$OSTYPE" == "linux") then
       tar xvf 9.0.2.tar.gz
       cd "${SOLPSTOP}/lib/${HOST_NAME}.${COMPILER}/json-fortran-9.0.2"
       mkdir -p build
-      cmake -S ${SOLPSTOP}/lib/${HOST_NAME}.${COMPILER}/json-fortran-9.0.2 ${SOLPSTOP}/lib/${HOST_NAME}.${COMPILER}/json-fortran-9.0.2/build
+      cmake -S ${SOLPSTOP}/lib/${HOST_NAME}.${COMPILER}/json-fortran-9.0.2 -B ${SOLPSTOP}/lib/${HOST_NAME}.${COMPILER}/json-fortran-9.0.2/build
       cd build
       make
       mkdir -p ${SOLPSTOP}/lib/${HOST_NAME}.${COMPILER}/json-fortran-9.0.2/lib

--- a/scripts/install_miniforge
+++ b/scripts/install_miniforge
@@ -25,14 +25,26 @@ if (! -d "${CONDA_ROOT}" ) then
     # Go to the installation directory
     cd $SOLPSTOP/lib/${HOST_NAME}.${COMPILER}
 
-    # Download Miniforge installer (assuming to be in a x86_64 Linux environment)
-    wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
-
+    # Detect OS and architecture
+    set OS = `uname -s`
+    set ARCH = `uname -m`
+    if ( "$OS" == "Linux" && "$ARCH" == "x86_64" ) then
+      set MINIFORGE_INSTALLER = "Miniforge3-Linux-x86_64.sh"
+    else if ( "$OS" == "Linux" && "$ARCH" == "aarch64" ) then
+      set MINIFORGE_INSTALLER = "Miniforge3-Linux-aarch64.sh"
+    else
+      echo "Unsupported OS/architecture: $OS $ARCH"
+      exit 1
+    endif
+    
+    # Download Miniforge installer
+    wget https://github.com/conda-forge/miniforge/releases/latest/download/${MINIFORGE_INSTALLER}
+    
     # Install Miniforge in batch mode at $CONDA_ROOT
-    bash Miniforge3-Linux-x86_64.sh -b -p $CONDA_ROOT
-
-    # Remove installed
-    rm Miniforge3-Linux-x86_64.sh
+    bash ${MINIFORGE_INSTALLER} -b -p $CONDA_ROOT
+    
+    # Remove installer
+    rm ${MINIFORGE_INSTALLER}
 
     # Initialize conda
     ${CONDA_ROOT}/bin/conda init tcsh


### PR DESCRIPTION
Playing a bit I have found out that the code can be compiled flawlessly also on Linux computers with ARM architecture. Only a minimal correction is needed.

For now I succeeded in compiling only B2.5, Eirene and DivGeo. For the rest, there is the issue that, apparently, NCARG has never been built so far on Linux ARM. Plus, also gr and gks will need some more adaptation.

Nevertheless, I thought that this was already worth a PR.