### PR TITLE
Fixed broken detection of presence of motif library on DARWIN

### DIFF
--- a/setup.csh
+++ b/setup.csh
@@ -395,6 +395,7 @@ if (! $?NO_MOTIF) then
     set _xm_found = 0
   endif
   if ($_xm_found == 0) set _xm_found = `sh -c 'find /usr/include /usr/local/include -name "Xm.h" -print 2>/dev/null' | wc -l`
+  if ($_xm_found == 0 && `uname` == Darwin) set _xm_found = `sh -c 'find -L /opt/homebrew/include /usr/local/include -name "Xm.h" -print 2>/dev/null' | wc -l`
   if ($_xm_found == 0) setenv NO_MOTIF 1
   unset _xm_found
 endif


### PR DESCRIPTION
Before a recent commit, dated at the end of June (c6b5cbc8 for the develop branch, 8c4cf606 for the WG branch), `DivGeo` built fine on macOS: Motif was detected via `mwm` and `libXm`, both present with a Homebrew OpenMotif install. That commit added an `Xm.h` header check that searches only `/usr/include` and `/usr/local/include` with plain `find`, which misses Homebrew (headers live under `/opt/homebrew` on MacOS, and `Xm` is a symlinked directory that needs `find -L`). It therefore sets `NO_MOTIF` and skips DivGeo even though OpenMotif is installed - a regression on MacOS.
Added a Darwin-only fallback searching the Homebrew prefix with `find -L`; other hosts are unaffected.
The very same line needs to be added, at the very same place, also on the `release/3.1.2` and on the `feature/wg-release` branches.