### PR TITLE
Added robustness of fetch_adas_datafiles

### DIFF
--- a/scripts/fetch_adas_datafiles
+++ b/scripts/fetch_adas_datafiles
@@ -10,6 +10,7 @@ set bundled_root = "$data_root/adas_bundled"
 set adf11_root   = "$data_root/adf11"
 set adf15_root   = "$data_root/adf15"
 set bundled_marker = "$bundled_root/.solps-fetch-complete"
+
 set tmp_root = "/tmp"
 if ($?TMPDIR) then
   if ("$TMPDIR" != "") set tmp_root = "$TMPDIR"
@@ -20,6 +21,11 @@ set adf15_manifest = "$work_dir/adf15_manifest"
 
 mkdir -p "$work_dir"
 mkdir -p "$bundled_root" "$adf11_root" "$adf15_root"
+if (-d "$SOLPSTOP/modules/adas" && ! -l "$SOLPSTOP/modules/adas" && `find "$SOLPSTOP/modules/adas" -mindepth 1 -maxdepth 1 -print -quit | wc -l` == 0) then
+  foreach adas_entry (`find "$data_root" -mindepth 1 -maxdepth 1 -print`)
+    ln -s "$adas_entry" "$SOLPSTOP/modules/adas/$adas_entry:t"
+  end
+endif
 
 set downloader = ""
 which curl >& /dev/null


### PR DESCRIPTION
Little change that might be useful. In case the modules/adas folder exists but is empty (so no access to ITER amds-adas repo), so `fetch_adas_datafiles` downloads the various files in data.local/adas, then the script also creates symlinks into modules/adas of the folders present in data.local/adas. This does not create confusion in the parent SOLPS-ITER repository (because in this case modules/adas is not seen as a submodule at all) and increases portability of run directories which were created into an installation which does have an available amds-adas subrepo (therefore `fort.1` contains the line
`CFILE ADAS   modules/adas/adf11`
which would not make usable in an installation in which, instead, the adas datafiles are fetched via the script).